### PR TITLE
Update Identifier Regex to allow for slash character

### DIFF
--- a/src/fixtures/003-schema.zed
+++ b/src/fixtures/003-schema.zed
@@ -1,0 +1,12 @@
+definition some_namespace/some_object_type {
+    relation viewer: user
+    permission view = viewer
+}
+
+definition user {}
+
+definition some/really/deep/namespace/resource {
+    relation owner: user
+    relation viewer: user | some_namespace/some_object_type#viewer
+    permission read = viewer + owner
+}

--- a/src/schema-parser/parser.test.ts
+++ b/src/schema-parser/parser.test.ts
@@ -15,8 +15,13 @@ const schema1 = fs.readFileSync(
 )
 
 const schema2 = fs.readFileSync(
-  new URL('../fixtures/002-schema.zed', import.meta.url),
-  'utf-8',
+    new URL('../fixtures/002-schema.zed', import.meta.url),
+    'utf-8',
+)
+
+const schema3 = fs.readFileSync(
+    new URL('../fixtures/003-schema.zed', import.meta.url),
+    'utf-8',
 )
 
 // Helper Functions
@@ -363,4 +368,14 @@ describe('parseSpiceDBSchema for 002-schema.zed', () => {
     }).not.toThrow()
     expect(result).toBeDefined()
   })
+})
+
+describe('parseSpiceDBSchema for 003-schema.zed', () => {
+    it('parses the schema with namespace prefixes (fixture 3) without error', () => {
+        let result
+        expect(() => {
+            result = parseSpiceDBSchema(schema3)
+        }).not.toThrow()
+        expect(result).toBeDefined()
+    })
 })

--- a/src/schema-parser/parser.ts
+++ b/src/schema-parser/parser.ts
@@ -7,7 +7,7 @@ import { CstParser, createToken, ICstVisitor, Lexer } from 'chevrotain'
 // Literals and Identifiers
 const Identifier = createToken({
   name: 'Identifier',
-  pattern: /[a-zA-Z_][a-zA-Z0-9_]*/,
+  pattern: /([a-z][a-z0-9_]*[a-z0-9]\/)*[a-z][a-z0-9_]*[a-z0-9]/,
 })
 const Integer = createToken({ name: 'Integer', pattern: /0|[1-9]\d*/ })
 const StringLiteral = createToken({ name: 'StringLiteral', pattern: /"[^"]*"/ })


### PR DESCRIPTION
SpiceDB allows for `/` characters in object names (e.g. so that you can namespace your types). This change updates the Identifier regex to more closely align with [the regex from the SpiceDB documentation](https://authzed.com/docs/spicedb/concepts/zanzibar#identifiers) (but with the `{n,m}` repetition ranges changed to just `*`).